### PR TITLE
XS✔ ◾ Change docsify version in dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.14-alpine
 
-RUN apk add --no-cache tini && npm install -g docsify-cli@latest
+RUN apk add --no-cache tini && npm install -g docsify-cli@4.4.3
 
 COPY . /docs
 WORKDIR /docs


### PR DESCRIPTION
Change docsify cli version to 4.4.3 since the latest version (4.4.4) is not rendering slides